### PR TITLE
add examples to API docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,119 @@
 
 Hand Evaluation Library
 
-## Status
+## Examples
 
-In early development, not ready for use yet
+### Evaluate a hand to determine its poker rank
+
+```rust
+use telluric_handeval::poker::{HandRank, PokerRankedHand};
+use ionic_deckhandler::{Card, Deck, Rank, Suit};
+
+// This hand will be ranked as a flush
+
+let hand_arr1: [Card; 5] = [
+    Card::new(Rank::Queen, Suit::Clubs),
+    Card::new(Rank::Five, Suit::Clubs),
+    Card::new(Rank::Four, Suit::Clubs),
+    Card::new(Rank::King, Suit::Clubs),
+    Card::new(Rank::Three, Suit::Clubs),
+];
+assert_eq!(
+    hand_arr1.evaluate_hand(),
+    HandRank::Flush {
+        ranks: [Rank::King, Rank::Queen, Rank::Five, Rank::Four, Rank::Three]
+    }
+);
+
+// This hand will be ranked by the highest card
+
+let hand_arr: [Card; 5] = [
+    Card::new(Rank::Queen, Suit::Clubs),
+    Card::new(Rank::Five, Suit::Hearts),
+    Card::new(Rank::Eight, Suit::Diamonds),
+    Card::new(Rank::King, Suit::Spades),
+    Card::new(Rank::Ten, Suit::Clubs),
+];
+assert_eq!(
+    hand_arr.evaluate_hand(),
+    HandRank::Highest {
+        ranks: [Rank::King, Rank::Queen, Rank::Ten, Rank::Eight, Rank::Five]
+    }
+);
+```
+
+### Compare two hands to determine which ranks higher
+
+```rust
+use ionic_deckhandler::{Card, Rank, Suit};
+use std::cmp::Ordering;
+use telluric_handeval::poker::{HandRank, PokerRankedHand};
+
+// A pair of threes, Ace high
+let hand_arr1: [Card; 5] = [
+        Card::new(Rank::Ace, Suit::Clubs),
+        Card::new(Rank::Three, Suit::Hearts),
+        Card::new(Rank::Three, Suit::Diamonds),
+        Card::new(Rank::King, Suit::Clubs),
+        Card::new(Rank::Queen, Suit::Clubs),
+    ];
+
+// A Pair of threes, King high
+let hand_arr2: [Card; 5] = [
+        Card::new(Rank::Two, Suit::Clubs),
+        Card::new(Rank::Three, Suit::Hearts),
+        Card::new(Rank::Three, Suit::Diamonds),
+        Card::new(Rank::King, Suit::Clubs),
+        Card::new(Rank::Queen, Suit::Clubs),
+    ];
+
+// Flush, Ace high
+let hand_arr3 = [
+    Card::new(Rank::Queen, Suit::Hearts),
+    Card::new(Rank::Five, Suit::Hearts),
+    Card::new(Rank::Four, Suit::Hearts),
+    Card::new(Rank::King, Suit::Hearts),
+    Card::new(Rank::Ace, Suit::Hearts),
+];
+
+// Flush, King high (Clubs)
+let hand_arr4: [Card; 5] = [
+    Card::new(Rank::Queen, Suit::Clubs),
+    Card::new(Rank::Five, Suit::Clubs),
+    Card::new(Rank::Four, Suit::Clubs),
+    Card::new(Rank::King, Suit::Clubs),
+    Card::new(Rank::Three, Suit::Clubs),
+];
+
+// Flush, King high (Hearts)
+let hand_arr5: [Card; 5] = [
+    Card::new(Rank::Queen, Suit::Hearts),
+    Card::new(Rank::Five, Suit::Hearts),
+    Card::new(Rank::Four, Suit::Hearts),
+    Card::new(Rank::King, Suit::Hearts),
+    Card::new(Rank::Three, Suit::Hearts),
+];
+
+assert_eq!(
+        hand_arr1.evaluate_hand().cmp(&hand_arr2.evaluate_hand()),
+        Ordering::Greater
+    );
+
+assert_eq!(
+    hand_arr4.evaluate_hand().cmp(&hand_arr3.evaluate_hand()),
+    Ordering::Less
+);
+
+assert_eq!(
+    hand_arr4.evaluate_hand().cmp(&hand_arr2.evaluate_hand()),
+    Ordering::Greater
+);
+
+assert_eq!(
+    hand_arr4.evaluate_hand().cmp(&hand_arr5.evaluate_hand()),
+    Ordering::Equal
+);
+```
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,81 @@ pub mod poker {
     }
 
     impl Ord for HandRank {
+
+/// Compare two hands to determine which ranks higher
+///
+/// Examples:
+///
+/// ```rust
+/// use ionic_deckhandler::{Card, Rank, Suit};
+/// use std::cmp::Ordering;
+/// use telluric_handeval::poker::{HandRank, PokerRankedHand};
+///
+/// // A pair of threes, Ace high
+/// let hand_arr1: [Card; 5] = [
+///         Card::new(Rank::Ace, Suit::Clubs),
+///         Card::new(Rank::Three, Suit::Hearts),
+///         Card::new(Rank::Three, Suit::Diamonds),
+///         Card::new(Rank::King, Suit::Clubs),
+///         Card::new(Rank::Queen, Suit::Clubs),
+///     ];
+///
+/// // A Pair of threes, King high
+/// let hand_arr2: [Card; 5] = [
+///         Card::new(Rank::Two, Suit::Clubs),
+///         Card::new(Rank::Three, Suit::Hearts),
+///         Card::new(Rank::Three, Suit::Diamonds),
+///         Card::new(Rank::King, Suit::Clubs),
+///         Card::new(Rank::Queen, Suit::Clubs),
+///     ];
+///
+/// // Flush, Ace high
+/// let hand_arr3 = [
+///     Card::new(Rank::Queen, Suit::Hearts),
+///     Card::new(Rank::Five, Suit::Hearts),
+///     Card::new(Rank::Four, Suit::Hearts),
+///     Card::new(Rank::King, Suit::Hearts),
+///     Card::new(Rank::Ace, Suit::Hearts),
+/// ];
+///
+/// // Flush, King high (Clubs)
+/// let hand_arr4: [Card; 5] = [
+///     Card::new(Rank::Queen, Suit::Clubs),
+///     Card::new(Rank::Five, Suit::Clubs),
+///     Card::new(Rank::Four, Suit::Clubs),
+///     Card::new(Rank::King, Suit::Clubs),
+///     Card::new(Rank::Three, Suit::Clubs),
+/// ];
+///
+/// // Flush, King high (Hearts)
+/// let hand_arr5: [Card; 5] = [
+///     Card::new(Rank::Queen, Suit::Hearts),
+///     Card::new(Rank::Five, Suit::Hearts),
+///     Card::new(Rank::Four, Suit::Hearts),
+///     Card::new(Rank::King, Suit::Hearts),
+///     Card::new(Rank::Three, Suit::Hearts),
+/// ];
+///
+/// assert_eq!(
+///         hand_arr1.evaluate_hand().cmp(&hand_arr2.evaluate_hand()),
+///         Ordering::Greater
+///     );
+///
+/// assert_eq!(
+///     hand_arr4.evaluate_hand().cmp(&hand_arr3.evaluate_hand()),
+///     Ordering::Less
+/// );
+///
+/// assert_eq!(
+///     hand_arr4.evaluate_hand().cmp(&hand_arr2.evaluate_hand()),
+///     Ordering::Greater
+/// );
+///
+/// assert_eq!(
+///     hand_arr4.evaluate_hand().cmp(&hand_arr5.evaluate_hand()),
+///     Ordering::Equal
+/// );
+/// ```
         fn cmp(&self, other: &Self) -> Ordering {
             self.partial_cmp(&other)
                 .expect("Error getting hand ordering.")
@@ -365,6 +440,47 @@ pub mod poker {
     }
 
     impl PokerRankedHand for [Card; 5] {
+
+/// Evaluate a hand to determine its poker rank
+///
+/// Examples:
+///
+/// ```rust
+/// use telluric_handeval::poker::{HandRank, PokerRankedHand};
+/// use ionic_deckhandler::{Card, Deck, Rank, Suit};
+///
+/// // This hand will be ranked as a flush
+///
+/// let hand_arr1: [Card; 5] = [
+///     Card::new(Rank::Queen, Suit::Clubs),
+///     Card::new(Rank::Five, Suit::Clubs),
+///     Card::new(Rank::Four, Suit::Clubs),
+///     Card::new(Rank::King, Suit::Clubs),
+///     Card::new(Rank::Three, Suit::Clubs),
+/// ];
+/// assert_eq!(
+///     hand_arr1.evaluate_hand(),
+///     HandRank::Flush {
+///         ranks: [Rank::King, Rank::Queen, Rank::Five, Rank::Four, Rank::Three]
+///     }
+/// );
+///
+/// // This hand will be ranked by the highest card
+///
+/// let hand_arr: [Card; 5] = [
+///     Card::new(Rank::Queen, Suit::Clubs),
+///     Card::new(Rank::Five, Suit::Hearts),
+///     Card::new(Rank::Eight, Suit::Diamonds),
+///     Card::new(Rank::King, Suit::Spades),
+///     Card::new(Rank::Ten, Suit::Clubs),
+/// ];
+/// assert_eq!(
+///     hand_arr.evaluate_hand(),
+///     HandRank::Highest {
+///         ranks: [Rank::King, Rank::Queen, Rank::Ten, Rank::Eight, Rank::Five]
+///     }
+/// );
+/// ```
         fn evaluate_hand(&self) -> HandRank {
             // Algorithm source: https://nsayer.blogspot.com/2007/07/algorithm-for-evaluating-poker-hands.html
             let mut cards = *self;


### PR DESCRIPTION
@Jammyjamjamman , if you pull this branch and run `cargo doc --open`, you'll see it's difficult to find the examples for the "cmp" function. Is there any way to rewrite the code a little to make it more obvious?

If not, let's not spend much time on it. The same examples are in the readme.